### PR TITLE
moved Tcl code into C file

### DIFF
--- a/README
+++ b/README
@@ -25,7 +25,6 @@ make install
 To build a Wavesurfer plugin without installing the package, copy the
 following files into your .wavesurfer/<version>/plugins directory:
 
-snack_sndfile_ext.tcl
 sndfile.plug
 libsnack_sndfile_ext.so
 libsnack_sndfile_ext.so.0.0.0

--- a/pkgIndex.tcl.in
+++ b/pkgIndex.tcl.in
@@ -1,1 +1,1 @@
-package ifneeded @PACKAGE@ @VERSION@ [list load [file join $dir libsnack_sndfile_ext[info sharedlibextension]]]\n[list source [file join $dir snack_sndfile_ext.tcl]]
+package ifneeded @PACKAGE@ @VERSION@ [list load [file join $dir libsnack_sndfile_ext[info sharedlibextension]]]

--- a/snack_sndfile_ext.c
+++ b/snack_sndfile_ext.c
@@ -465,6 +465,72 @@ static int WriteSndSamples(Sound *s, Tcl_Channel ch, Tcl_Obj *obj, int start, in
 /* 	return 0; */
 /* } */
 
+/* This function is used instead of the snack_sndfile_ext.tcl script in order
+   to generate the tcl variables that are needed by snack. Doing it here allows
+   keeping the formats always up to date with the current version of libsndfile
+*/
+int CreateTclVariablesForSnack(Tcl_Interp *interp)
+{
+  int k, count ;
+  SF_FORMAT_INFO format_info ;
+  Tcl_Obj *scriptPtr = Tcl_NewStringObj("", 0);
+  Tcl_Obj *scriptPtr1 = Tcl_NewStringObj("", 0);
+  Tcl_Obj *scriptPtr2 = Tcl_NewStringObj("", 0);
+  Tcl_Obj *formatExtUC = Tcl_NewStringObj("", 0);
+
+  Tcl_AppendStringsToObj(scriptPtr,
+			 "namespace eval snack::snack_sndfile_ext {\n",
+			 "    variable extTypes\n",
+			 "    variable loadTypes\n",
+			 "    variable loadKeys\n\n", (char *) NULL);
+  Tcl_AppendStringsToObj(scriptPtr1, "    set extTypesMC {\n", (char *) NULL);
+  Tcl_AppendStringsToObj(scriptPtr2, "    set loadTypes {\n", (char *) NULL);
+
+  sf_command (NULL, SFC_GET_FORMAT_MAJOR_COUNT, &count, sizeof (int));
+  
+  for (k = 0 ; k < count ; k++) {
+    format_info.format = k ;
+    sf_command (NULL, SFC_GET_FORMAT_MAJOR, &format_info, sizeof (SF_FORMAT_INFO));
+
+    /* convert extension to upper case */
+    Tcl_SetStringObj(formatExtUC, format_info.extension, strlen(format_info.extension));
+    Tcl_UtfToUpper(Tcl_GetString(formatExtUC));
+
+    /* append to variable extTypesMC */
+    Tcl_AppendStringsToObj(scriptPtr1, "        {{", format_info.name,
+			   "} .", format_info.extension, "}\n", (char *) NULL);
+
+    /* append to variable loadTypes */
+    Tcl_AppendStringsToObj(scriptPtr2, "        {{", format_info.name,
+			   "} {.", format_info.extension,
+			   " .", Tcl_GetString(formatExtUC),
+			   "}}\n", (char *) NULL);
+  }
+  Tcl_AppendStringsToObj(scriptPtr1, "    }\n\n", (char *) NULL);
+  Tcl_AppendStringsToObj(scriptPtr2, "    }\n\n", (char *) NULL);
+
+  Tcl_AppendObjToObj(scriptPtr, scriptPtr1);
+  Tcl_AppendObjToObj(scriptPtr, scriptPtr2);
+
+  Tcl_AppendStringsToObj(scriptPtr,
+			 "    set extTypes [list]\n",
+			 "    set loadKeys [list]\n",
+			 "    foreach pair $extTypesMC {\n",
+			 "	set type [string toupper [lindex $pair 0]]\n",
+			 "	set ext [lindex $pair 1]\n",
+			 "	lappend extTypes [list $type $ext]\n",
+			 "	lappend loadKeys $type\n"
+			 "    }\n\n",
+			 "    snack::addLoadTypes $loadTypes $loadKeys\n",
+			 "    snack::addExtTypes $extTypes\n",
+			 "}\n", (char *) NULL);
+
+  fprintf(stderr, "%s\n", Tcl_GetString(scriptPtr));
+
+  return Tcl_EvalObjEx(interp, scriptPtr, TCL_EVAL_DIRECT);
+}
+
+
 /* Called by "load libsnacksndfile" */
 EXPORT(int, Snack_sndfile_ext_Init) _ANSI_ARGS_((Tcl_Interp *interp))
 {
@@ -472,7 +538,6 @@ EXPORT(int, Snack_sndfile_ext_Init) _ANSI_ARGS_((Tcl_Interp *interp))
 	int k, count ;
         SF_FORMAT_INFO format_info ;
 	Snack_FileFormat *SndFileFormatPtr;
-
 
 #ifdef USE_TCL_STUBS
 	if (Tcl_InitStubs(interp, "8", 0) == NULL) {
@@ -501,7 +566,6 @@ EXPORT(int, Snack_sndfile_ext_Init) _ANSI_ARGS_((Tcl_Interp *interp))
 	  sf_command (NULL, SFC_GET_FORMAT_MAJOR, &format_info, sizeof (SF_FORMAT_INFO));
 
 	  SndFileFormatPtr = (Snack_FileFormat *) malloc(sizeof(Snack_FileFormat));
-	  //SndFileFormatPtr->name = (char *) malloc(strlen(format_info.name)+1);
 	  /* only copy pointer to format name */
 	  SndFileFormatPtr->name = format_info.name;
 	  SndFileFormatPtr->guessProc = (guessFileTypeProc*) GuessSndFile;
@@ -517,11 +581,10 @@ EXPORT(int, Snack_sndfile_ext_Init) _ANSI_ARGS_((Tcl_Interp *interp))
 	  SndFileFormatPtr->configureProc = NULL;
 	  SndFileFormatPtr->nextPtr = (Snack_FileFormat*) NULL;
 
-	  //strcpy(SndFileFormatPtr->name, format_info.name);
 	  Snack_CreateFileFormat(SndFileFormatPtr);
 	}
 
-	return TCL_OK;
+	return CreateTclVariablesForSnack(interp);
 }
 
 EXPORT(int, Snacksndfile_SafeInit)(Tcl_Interp *interp)

--- a/snack_sndfile_ext.c
+++ b/snack_sndfile_ext.c
@@ -501,7 +501,9 @@ EXPORT(int, Snack_sndfile_ext_Init) _ANSI_ARGS_((Tcl_Interp *interp))
 	  sf_command (NULL, SFC_GET_FORMAT_MAJOR, &format_info, sizeof (SF_FORMAT_INFO));
 
 	  SndFileFormatPtr = (Snack_FileFormat *) malloc(sizeof(Snack_FileFormat));
-	  SndFileFormatPtr->name = (char *) malloc(strlen(format_info.name)+1);
+	  //SndFileFormatPtr->name = (char *) malloc(strlen(format_info.name)+1);
+	  /* only copy pointer to format name */
+	  SndFileFormatPtr->name = format_info.name;
 	  SndFileFormatPtr->guessProc = (guessFileTypeProc*) GuessSndFile;
 	  SndFileFormatPtr->getHeaderProc = GetSndHeader;
 	  SndFileFormatPtr->extProc = (extensionFileTypeProc*) ExtSndFile;
@@ -515,7 +517,7 @@ EXPORT(int, Snack_sndfile_ext_Init) _ANSI_ARGS_((Tcl_Interp *interp))
 	  SndFileFormatPtr->configureProc = NULL;
 	  SndFileFormatPtr->nextPtr = (Snack_FileFormat*) NULL;
 
-	  strcpy(SndFileFormatPtr->name, format_info.name);
+	  //strcpy(SndFileFormatPtr->name, format_info.name);
 	  Snack_CreateFileFormat(SndFileFormatPtr);
 	}
 

--- a/sndfile.plug
+++ b/sndfile.plug
@@ -34,9 +34,7 @@ set res [catch {package require snack_sndfile_ext}]
 # if it didn't work, load the version coming with this plugin
 if {$res} {
     set shlib [file join $dir libsnack_sndfile_ext[info sharedlibextension]]
-    if {[catch {load $shlib}] == 0} {
-	source [file join $dir snack_sndfile_ext.tcl]
-    }
+    catch {load $shlib}
 }
 
 # here check if plugin is functional and add formats to wavesurfer as well


### PR DESCRIPTION
Hi Giulio,
I moved the Tcl code from snack_sndfile_ext.tcl into snack_sndfile_ext.c. This way, not only we have a single installation file, but we also generate the list of formats automatically (no need to update the files every time a new format in added in libsndfile). I did not remove snack_sndfile_ext.tcl as yet. Waiting for more testing first.

I also removed the allocation for the format names as we discussed: we are now relying on the strings allocated by libsndfile.

Enjoy!
