### PR TITLE
Modernize build scripts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ versionedpkglib_LTLIBRARIES = libsnack_sndfile_ext.la
 libsnack_sndfile_ext_la_SOURCES = \
 	snack_sndfile_ext.c
 libsnack_sndfile_ext_la_CFLAGS = @SNACK_INCLUDE_SPEC@ @TCL_INCLUDE_SPEC@ @SNDFILE_CFLAGS@
-libsnack_sndfile_ext_la_LDFLAGS = -version-info 0:0:0 @SNACK_LIB_SPEC@ @TCL_LIB_SPEC@ @SNDFILE_LIBS@
+libsnack_sndfile_ext_la_LDFLAGS = -version-info 0:0:0 -no-undefined @SNACK_LIB_SPEC@ @TCL_LIB_SPEC@ @SNDFILE_LIBS@
 #               TCL_STUB_LIB_FLAG
 #               TCL_STUB_LIB_SPEC
 #               TCL_STUB_LIB_FILE

--- a/configure.ac
+++ b/configure.ac
@@ -16,8 +16,7 @@ AM_MAINTAINER_MODE
 dnl Checks for programs.
 AC_PROG_CC
 
-AC_LIBTOOL_WIN32_DLL
-AC_PROG_LIBTOOL
+LT_INIT([disable-static win32-dll])
 
 SC_PATH_TCLCONFIG
 dnl SC_PATH_TKCONFIG
@@ -72,8 +71,7 @@ AC_SUBST(CFLAGS)
 AC_SUBST(TCL_LIB_SPEC)
 AC_SUBST(SNACK_LIB_SPEC)
 dnl Checks for header files.
-AC_CHECK_HEADERS(string.h math.h locale.h)
-AC_HEADER_STDC
+AC_CHECK_HEADERS([string.h math.h locale.h], [], [], [AC_INCLUDES_DEFAULT])
 dnl Checks for compiler characteristics.
 dnl AC_ISC_POSIX
 AC_C_INLINE
@@ -84,4 +82,4 @@ Makefile
 pkgIndex.tcl
 ])
 
-AC_OUTPUT([])
+AC_OUTPUT

--- a/test.tcl
+++ b/test.tcl
@@ -1,6 +1,6 @@
 #!/bin/sh
 # the next line restarts using wish \
-exec wish8.4 "$0" "$@"
+exec wish "$0" "$@"
 
 # 'info sharedlibext' returns '.dll' on Windows and '.so' on most Unix systems
 


### PR DESCRIPTION
These are some minor changes to update `configure.ac` and `Makefile.am` for newer versions of autoconf and libtool as well as `test.tcl` for Tcl versions beyond 8.4. All these changes should be backward compatible and work with versions of autconf, libtool and tcl from the past years just as well.